### PR TITLE
feat: add ValueError exception class

### DIFF
--- a/src/Exceptions/ValueError.php
+++ b/src/Exceptions/ValueError.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Kambo\Langchain\Exceptions;
+
+class ValueError extends LangChain
+{
+}

--- a/src/Prompts/BasePromptTemplate.php
+++ b/src/Prompts/BasePromptTemplate.php
@@ -3,7 +3,8 @@
 namespace Kambo\Langchain\Prompts;
 
 use SplFileInfo;
-use ValueError;
+use Kambo\Langchain\Prompts\OutputParser\BaseOutputParser;
+use Kambo\Langchain\Exceptions\ValueError;
 
 use function array_intersect;
 use function implode;
@@ -67,9 +68,9 @@ abstract class BasePromptTemplate
     public function partial(array $arguments): BasePromptTemplate
     {
         $promptDict = $this->toArray();
-        $promptDict['input_variables'] = array_diff($this->inputVariables, array_keys($arguments));
+        $inputVariables = array_diff($this->inputVariables, array_keys($arguments));
         $promptDict['partial_variables'] = array_merge($this->partialVariables, $arguments);
-        return new static($promptDict);
+        return new static($promptDict['template'], $inputVariables, $promptDict);
     }
 
     protected function mergePartialAndUserVariables(array $kwargs): array
@@ -83,7 +84,23 @@ abstract class BasePromptTemplate
 
     abstract public function toArray();
 
+    /**
+     * Format the prompt with the inputs.
+     *
+     * @param array $parameters Any arguments to be passed to the prompt template.
+     *
+     * @return string A formatted string.
+     */
     abstract public function format(array $parameters): string;
+
+    /**
+     * Create Chat Messages.
+     *
+     * @param array $parameters Any arguments to be passed to the prompt template.
+     *
+     * @return PromptValue
+     */
+    abstract public function formatPrompt(array $parameters): PromptValue;
 
     /**
      * Save the prompt.

--- a/src/Prompts/OutputParser/BaseOutputParser.php
+++ b/src/Prompts/OutputParser/BaseOutputParser.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Kambo\Langchain\Prompts\OutputParser;
+
+use Kambo\Langchain\Exceptions\NotImplemented;
+use Kambo\Langchain\Prompts\PromptValue;
+
+/**
+ * Class to parse the output of an LLM call.
+ *
+ * Output parsers help structure language model responses.
+ * They are used in conjunction with PromptTemplates to
+ * help structure the output of a language model call.
+ */
+abstract class BaseOutputParser
+{
+    /**
+     * Parse the output of an LLM call.
+     *
+     * A method which takes in a string (assumed output of language model)
+     * and parses it into some structure.
+     *
+     * @param string $text Output of language model
+     * @return mixed Structured output
+     */
+    abstract public function parse(string $text);
+
+    /**
+     * Optional method to parse the output of an LLM call with a prompt.
+     *
+     * The prompt is largely provided in the event the OutputParser wants
+     * to retry or fix the output in some way, and needs information from
+     * the prompt to do so.
+     *
+     * @param string $completion Output of language model
+     * @param PromptValue $prompt Prompt value
+     *
+     * @return mixed Structured output
+     */
+    public function parseWithPrompt(string $completion, PromptValue $prompt)
+    {
+        return $this->parse($completion);
+    }
+
+    /**
+     * Instructions on how the LLM output should be formatted.
+     *
+     * @return string
+     */
+    public function getFormatInstructions()
+    {
+        throw new NotImplemented();
+    }
+
+    /**
+     * Return the type key.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        throw new NotImplemented();
+    }
+
+    /**
+     * Return dictionary representation of output parser.
+     *
+     * @param array $additionalParameters Additional parameters to include in the output
+     * @return array
+     */
+    abstract public function toArray(array $additionalParameters = []): array;
+}

--- a/src/Prompts/OutputParser/RegexParser.php
+++ b/src/Prompts/OutputParser/RegexParser.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Kambo\Langchain\Prompts\OutputParser;
+
+use Kambo\Langchain\Exceptions\ValueError;
+
+use function preg_match;
+use function array_combine;
+use function array_slice;
+use function array_fill_keys;
+use function array_merge;
+
+/**
+ * Output parser that uses a regular expression to parse the output.
+ */
+final class RegexParser extends BaseOutputParser
+{
+    public string $regex;
+    public array $outputKeys;
+    public ?string $defaultOutputKey;
+
+    /**
+     * RegexParser constructor.
+     *
+     * @param string $regex
+     * @param array $outputKeys
+     * @param string|null $defaultOutputKey
+     */
+    public function __construct(string $regex, array $outputKeys, ?string $defaultOutputKey = null)
+    {
+        $this->regex = $regex;
+        $this->outputKeys = $outputKeys;
+        $this->defaultOutputKey = $defaultOutputKey;
+    }
+
+    /**
+     * Return the type key.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return 'regex_parser';
+    }
+
+    /**
+     * Parse the output of an LLM call.
+     *
+     * @param string $text
+     * @return array
+     */
+    public function parse(string $text)
+    {
+        if (preg_match($this->regex, $text, $matches)) {
+            return array_combine(
+                $this->outputKeys,
+                array_slice($matches, 1)
+            );
+        } else {
+            if ($this->defaultOutputKey === null) {
+                throw new ValueError('Could not parse output: ' . $text);
+            } else {
+                return array_fill_keys(
+                    $this->outputKeys,
+                    $this->defaultOutputKey
+                );
+            }
+        }
+    }
+
+    /**
+     * Return dictionary representation of output parser.
+     *
+     * @param array $additionalParameters Additional parameters to include in the output
+     * @return array
+     */
+    public function toArray(array $additionalParameters = []): array
+    {
+        return array_merge(
+            [
+                'regex' => $this->regex,
+                'output_keys' => $this->outputKeys,
+                'default_output_key' => $this->defaultOutputKey,
+                'type' => $this->getType(),
+            ],
+            $additionalParameters
+        );
+    }
+}

--- a/tests/Prompts/OutputParser/RegexParserTest.php
+++ b/tests/Prompts/OutputParser/RegexParserTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Kambo\Langchain\Tests\Prompts\OutputParser;
+
+use Kambo\Langchain\Exceptions\ValueError;
+use Kambo\Langchain\Prompts\OutputParser\RegexParser;
+use PHPUnit\Framework\TestCase;
+
+class RegexParserTest extends TestCase
+{
+    public function testGetTypeReturnsCorrectType()
+    {
+        $regexParser = new RegexParser('', []);
+        $this->assertEquals('regex_parser', $regexParser->getType());
+    }
+
+    public function testParseReturnsCorrectArrayWhenRegexMatches()
+    {
+        $regex = '/^The (cat|dog) chased the (mouse|rat)$/i';
+        $outputKeys = ['animal', 'prey'];
+        $defaultOutputKey = null;
+        $regexParser = new RegexParser($regex, $outputKeys, $defaultOutputKey);
+
+        $text = 'The cat chased the mouse';
+        $expectedOutput = [
+            'animal' => 'cat',
+            'prey' => 'mouse'
+        ];
+        $this->assertEquals($expectedOutput, $regexParser->parse($text));
+    }
+
+    public function testParseThrowsValueErrorWhenRegexDoesNotMatchAndDefaultOutputKeyIsNull()
+    {
+        $regex = '/^The (cat|dog) chased the (mouse|rat)$/i';
+        $outputKeys = ['animal', 'prey'];
+        $defaultOutputKey = null;
+        $regexParser = new RegexParser($regex, $outputKeys, $defaultOutputKey);
+
+        $text = 'The bird flew away';
+        $this->expectException(ValueError::class);
+        $regexParser->parse($text);
+    }
+
+    public function testParseReturnsArrayWithDefaultOutputKeyWhenRegexDoesNotMatchAndDefaultOutputKeyIsNotNull()
+    {
+        $regex = '/^The (cat|dog) chased the (mouse|rat)$/i';
+        $outputKeys = ['animal', 'prey'];
+        $defaultOutputKey = 'unknown';
+        $regexParser = new RegexParser($regex, $outputKeys, $defaultOutputKey);
+
+        $text = 'The bird flew away';
+        $expectedOutput = [
+            'animal' => 'unknown',
+            'prey' => 'unknown'
+        ];
+        $this->assertEquals($expectedOutput, $regexParser->parse($text));
+    }
+
+    public function testToArrayReturnsCorrectArray()
+    {
+        $regex = '/^The (cat|dog) chased the (mouse|rat)$/i';
+        $outputKeys = ['animal', 'prey'];
+        $defaultOutputKey = 'unknown';
+        $regexParser = new RegexParser($regex, $outputKeys, $defaultOutputKey);
+
+        $additionalParameters = [
+            'language' => 'en',
+            'version' => '1.0'
+        ];
+        $expectedOutput = [
+            'regex' => $regex,
+            'output_keys' => $outputKeys,
+            'default_output_key' => $defaultOutputKey,
+            'type' => 'regex_parser',
+            'language' => 'en',
+            'version' => '1.0'
+        ];
+        $this->assertEquals($expectedOutput, $regexParser->toArray($additionalParameters));
+    }
+}

--- a/tests/Prompts/PromptTemplateTest.php
+++ b/tests/Prompts/PromptTemplateTest.php
@@ -39,6 +39,18 @@ final class PromptTemplateTest extends TestCase
         $this->assertEquals($inputVariables, $prompt->getInputVariables());
     }
 
+    public function testPromptFormat(): void
+    {
+        $template = 'This is a {foo} test.';
+        $inputVariables = ['foo'];
+        $prompt = new PromptTemplate(
+            $template,
+            $inputVariables,
+        );
+
+        $this->assertEquals('This is a bar test.', $prompt->format(['foo' => 'bar']));
+    }
+
     public function testPromptFromTemplate()
     {
         // Single input variable.


### PR DESCRIPTION
add BaseOutputParser class to parse the output of an LLM call. It includes methods to parse the output with or without a prompt, instructions on how the LLM output should be formatted, and a method to return the type key.
add RegexParser class for parsing output using regular expressions