### PR TITLE
Add support for ChatPromptTemplate

### DIFF
--- a/examples/chat-prompt-template.php
+++ b/examples/chat-prompt-template.php
@@ -1,0 +1,34 @@
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+use Kambo\Langchain\Prompts\ChatPromptTemplate;
+use Kambo\Langchain\Prompts\HumanMessagePromptTemplate;
+use Kambo\Langchain\Prompts\SystemMessagePromptTemplate;
+use Kambo\Langchain\Prompts\PromptTemplate;
+
+$template="You are a helpful assistant that translates {input_language} to {output_language}.";
+$systemMessagePrompt = SystemMessagePromptTemplate::fromTemplate($template);
+$humanTemplate="{text}";
+$humanMessagePrompt = HumanMessagePromptTemplate::fromTemplate($humanTemplate);
+
+$chatPrompt = ChatPromptTemplate::fromMessages([$systemMessagePrompt, $humanMessagePrompt]);
+$out = $chatPrompt->formatPrompt(
+    [
+        'input_language' => 'English',
+        'output_language' => 'Spanish',
+        'text'=>'I love programming.'
+    ]
+)->toMessages();
+var_dump($out);
+
+
+$prompt = new PromptTemplate(
+    "You are a helpful assistant that translates {input_language} to {output_language}.",
+    ["input_language", "output_language"],
+);
+
+
+$systemMessagePrompt = new SystemMessagePromptTemplate($prompt);
+echo $systemMessagePrompt->format(['input_language' => 'English', 'output_language' => 'Spanish'])->formatChatML();
+

--- a/src/Memory/ConversationBufferWindowMemory.php
+++ b/src/Memory/ConversationBufferWindowMemory.php
@@ -6,6 +6,7 @@ use Kambo\Langchain\Message\HumanMessage;
 use Kambo\Langchain\Message\AIMessage;
 use Kambo\Langchain\Message\SystemMessage;
 use Kambo\Langchain\Message\ChatMessage;
+use Kambo\Langchain\Message\Utils;
 use Exception;
 
 use function array_slice;
@@ -78,23 +79,6 @@ class ConversationBufferWindowMemory extends BaseChatMemory
      */
     public function getBufferString(array $messages, string $humanPrefix = 'Human', string $aiPrefix = 'AI'): string
     {
-        $stringMessages = [];
-        foreach ($messages as $m) {
-            if ($m instanceof HumanMessage) {
-                $role = $humanPrefix;
-            } elseif ($m instanceof AIMessage) {
-                $role = $aiPrefix;
-            } elseif ($m instanceof SystemMessage) {
-                $role = 'System';
-            } elseif ($m instanceof ChatMessage) {
-                $role = $m->getRole();
-            } else {
-                throw new Exception(sprintf('Got unsupported message type: %s', get_class($m)));
-            }
-
-            $stringMessages[] = sprintf('%s: %s', $role, $m->content);
-        }
-
-        return implode("\n", $stringMessages);
+        return Utils::getBufferString($messages, $humanPrefix, $aiPrefix);
     }
 }

--- a/src/Message/BaseMessage.php
+++ b/src/Message/BaseMessage.php
@@ -26,4 +26,9 @@ abstract class BaseMessage
      * @return string
      */
     abstract public function getType(): string;
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
 }

--- a/src/Message/Utils.php
+++ b/src/Message/Utils.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Kambo\Langchain\Message;
+
+use Kambo\Langchain\Exceptions\IllegalState;
+
+use function sprintf;
+use function get_class;
+use function implode;
+
+class Utils
+{
+    /**
+     * Get buffer string of messages.
+     *
+     * @param array  $messages
+     * @param string $humanPrefix
+     * @param string $aiPrefix
+     *
+     * @return string
+     */
+    public static function getBufferString(
+        array $messages,
+        string $humanPrefix = 'Human',
+        string $aiPrefix = 'AI'
+    ): string {
+        $stringMessages = [];
+        foreach ($messages as $m) {
+            if ($m instanceof HumanMessage) {
+                $role = $humanPrefix;
+            } elseif ($m instanceof AIMessage) {
+                $role = $aiPrefix;
+            } elseif ($m instanceof SystemMessage) {
+                $role = 'System';
+            } elseif ($m instanceof ChatMessage) {
+                $role = $m->getRole();
+            } else {
+                throw new IllegalState(sprintf('Got unsupported message type: %s', get_class($m)));
+            }
+
+            $stringMessages[] = sprintf('%s: %s', $role, $m->content);
+        }
+
+        return implode("\n", $stringMessages);
+    }
+}

--- a/src/Prompts/AIMessagePromptTemplate.php
+++ b/src/Prompts/AIMessagePromptTemplate.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Kambo\Langchain\Prompts;
+
+use Kambo\Langchain\Message\BaseMessage;
+use Kambo\Langchain\Message\AIMessage;
+
+final class AIMessagePromptTemplate extends BaseStringMessagePromptTemplate
+{
+    /**
+     * Format the prompt and return a BaseMessage
+     *
+     * @param array $arguments
+     * @return BaseMessage
+     */
+    public function format(array $arguments = []): BaseMessage
+    {
+        $text = $this->prompt->format($arguments);
+        return new AIMessage($text, $arguments);
+    }
+}

--- a/src/Prompts/BaseChatPromptTemplate.php
+++ b/src/Prompts/BaseChatPromptTemplate.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Kambo\Langchain\Prompts;
+
+use Kambo\Langchain\Message\BaseMessage;
+
+abstract class BaseChatPromptTemplate extends BasePromptTemplate
+{
+    /**
+     * Format the prompt and return a string
+     *
+     * @param array $arguments
+     * @return string
+     */
+    public function format(array $arguments = []): string
+    {
+        return $this->formatPrompt($arguments)->toString();
+    }
+
+    /**
+     * Format the prompt and return a ChatPromptValue object
+     *
+     * @param array $arguments
+     * @return PromptValue
+     */
+    public function formatPrompt(array $arguments = []): PromptValue
+    {
+        $messages = $this->formatMessages($arguments);
+        return new ChatPromptValue($messages);
+    }
+
+    /**
+     * Format arguments into a list of messages
+     *
+     * @param array $arguments
+     * @return BaseMessage[]
+     */
+    abstract protected function formatMessages(array $arguments = []): array;
+}

--- a/src/Prompts/BaseMessagePromptTemplate.php
+++ b/src/Prompts/BaseMessagePromptTemplate.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Kambo\Langchain\Prompts;
+
+use Kambo\Langchain\Message\BaseMessage;
+
+abstract class BaseMessagePromptTemplate
+{
+    /**
+     * Format arguments into a list of messages
+     *
+     * @param array $arguments
+     * @return BaseMessage[]
+     */
+    abstract public function formatMessages(array $arguments = []): array;
+
+    /**
+     * Get input variables for this prompt template
+     *
+     * @return array
+     */
+    abstract public function getInputVariables(): array;
+}

--- a/src/Prompts/BasePromptTemplate.php
+++ b/src/Prompts/BasePromptTemplate.php
@@ -74,13 +74,13 @@ abstract class BasePromptTemplate
         return new static($promptDict['template'], $inputVariables, $promptDict);
     }
 
-    protected function mergePartialAndUserVariables(array $kwargs): array
+    protected function mergePartialAndUserVariables(array $arguments): array
     {
         // Get partial params:
         $partialKwargs = array_map(function ($v) {
             return is_callable($v) ? $v() : $v ;
         }, $this->partialVariables);
-        return array_merge($partialKwargs, $kwargs);
+        return array_merge($partialKwargs, $arguments);
     }
 
     abstract public function toArray();

--- a/src/Prompts/BaseStringMessagePromptTemplate.php
+++ b/src/Prompts/BaseStringMessagePromptTemplate.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Kambo\Langchain\Prompts;
+
+use Kambo\Langchain\Message\BaseMessage;
+
+abstract class BaseStringMessagePromptTemplate extends BaseMessagePromptTemplate
+{
+    protected StringPromptTemplate $prompt;
+    protected array $additionalArguments = [];
+
+    /**
+     * @param PromptTemplate $prompt
+     * @param array          $arguments
+     */
+    public function __construct(PromptTemplate $prompt, array $arguments = [])
+    {
+        $this->prompt = $prompt;
+        $this->additionalArguments = $arguments;
+    }
+
+    /**
+     * @param string $template
+     * @param array $arguments
+     *
+     * @return BaseMessagePromptTemplate
+     */
+    public static function fromTemplate(string $template, array $arguments = []): BaseMessagePromptTemplate
+    {
+        $prompt = PromptTemplate::fromTemplate($template);
+        return new static($prompt, $arguments);
+    }
+
+    /**
+     * Format arguments into a BaseMessage
+     *
+     * @param array $arguments
+     * @return BaseMessage
+     */
+    abstract public function format(array $arguments = []): BaseMessage;
+
+    /**
+     * Format arguments into a list of messages
+     *
+     * @param array $arguments
+     * @return BaseMessage[]
+     */
+    public function formatMessages(array $arguments = []): array
+    {
+        return [$this->format($arguments)];
+    }
+
+    /**
+     * Get input variables for this prompt template
+     *
+     * @return array
+     */
+    public function getInputVariables(): array
+    {
+        return $this->prompt->getInputVariables();
+    }
+}

--- a/src/Prompts/ChatMessagePromptTemplate.php
+++ b/src/Prompts/ChatMessagePromptTemplate.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Kambo\Langchain\Prompts;
+
+use Kambo\Langchain\Message\BaseMessage;
+use Kambo\Langchain\Message\ChatMessage;
+
+class ChatMessagePromptTemplate extends BaseStringMessagePromptTemplate
+{
+    protected string $role;
+
+    public function __construct(PromptTemplate $prompt, string $role = '', array $arguments = [])
+    {
+        $this->role = $role;
+        parent::__construct($prompt, $arguments);
+    }
+
+    /**
+     * Format the prompt and return a BaseMessage
+     *
+     * @param array $arguments
+     * @return BaseMessage
+     */
+    public function format(array $arguments = []): BaseMessage
+    {
+        $text = $this->prompt->format($arguments);
+        return new ChatMessage(
+            $text,
+            $this->role,
+            $arguments
+        );
+    }
+}

--- a/src/Prompts/ChatPromptTemplate.php
+++ b/src/Prompts/ChatPromptTemplate.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Kambo\Langchain\Prompts;
+
+use Kambo\Langchain\Message\BaseMessage;
+use Kambo\Langchain\Exceptions\InvalidArgumentException;
+use Kambo\Langchain\Exceptions\NotImplemented;
+use SplFileInfo;
+
+use function array_map;
+use function array_merge;
+use function array_values;
+use function array_unique;
+use function array_intersect_key;
+use function array_flip;
+
+class ChatPromptTemplate extends BaseChatPromptTemplate
+{
+    public function __construct(
+        public array $messages,
+        public array $inputVariables,
+    ) {
+    }
+
+    public static function fromRoleStrings(array $stringMessages): ChatPromptTemplate
+    {
+        $messages = array_map(
+            function ($tuple) {
+                [$role, $template] = $tuple;
+                return new ChatMessagePromptTemplate(
+                    PromptTemplate::fromTemplate($template),
+                    $role
+                );
+            },
+            $stringMessages
+        );
+
+        return self::fromMessages($messages);
+    }
+
+    public static function fromStrings(array $stringMessages): ChatPromptTemplate
+    {
+        $messages = array_map(
+            function ($tuple) {
+                [$role, $template] = $tuple;
+                return new $role([
+                    'content' => PromptTemplate::fromTemplate($template)
+                ]);
+            },
+            $stringMessages
+        );
+
+        return self::fromMessages($messages);
+    }
+
+    public static function fromMessages(array $messages): ChatPromptTemplate
+    {
+        $inputVars = [];
+
+        foreach ($messages as $message) {
+            if ($message instanceof BaseMessagePromptTemplate) {
+                $inputVars = array_merge($inputVars, $message->getInputVariables());
+            }
+        }
+
+        return new self($messages, array_values(array_unique($inputVars)));
+    }
+
+    public function format(array $arguments = []): string
+    {
+        return (string)$this->formatPrompt($arguments);
+    }
+
+    public function getInputVariables(): array
+    {
+        return $this->inputVariables;
+    }
+
+    public function getMessages(): array
+    {
+        return $this->messages;
+    }
+
+    protected function formatMessages(array $arguments = []): array
+    {
+        $arguments = $this->mergePartialAndUserVariables($arguments);
+        $result = [];
+
+        foreach ($this->messages as $messageTemplate) {
+            if ($messageTemplate instanceof BaseMessage) {
+                $result[] = $messageTemplate;
+            } elseif ($messageTemplate instanceof BaseMessagePromptTemplate) {
+                $relParams = array_intersect_key($arguments, array_flip($messageTemplate->getInputVariables()));
+                $message = $messageTemplate->formatMessages($relParams);
+                $result = array_merge($result, $message);
+            } else {
+                throw new InvalidArgumentException('Unexpected input: ' . $messageTemplate);
+            }
+        }
+
+        return $result;
+    }
+
+    public function partial(array $arguments = []): BasePromptTemplate
+    {
+        throw new NotImplemented('Method not implemented.');
+    }
+
+    public function getPromptType(): string
+    {
+        throw new NotImplemented('Method not implemented.');
+    }
+
+    public function save(string|SplFileInfo $filePath): void
+    {
+        throw new NotImplemented('Method not implemented.');
+    }
+
+    public function toArray()
+    {
+        return [
+            'messages' => $this->messages,
+            'inputVariables' => $this->inputVariables,
+        ];
+    }
+}

--- a/src/Prompts/ChatPromptValue.php
+++ b/src/Prompts/ChatPromptValue.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Kambo\Langchain\Prompts;
+
+use Kambo\Langchain\Message\BaseMessage;
+use Kambo\Langchain\Message\Utils;
+
+class ChatPromptValue implements PromptValue
+{
+    public function __construct(protected array $messages)
+    {
+    }
+
+    /**
+     * Return prompt as a string
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return Utils::getBufferString($this->messages);
+    }
+
+    /**
+     * Return prompt as messages
+     *
+     * @return BaseMessage[]
+     */
+    public function toMessages(): array
+    {
+        return $this->messages;
+    }
+}

--- a/src/Prompts/HumanMessagePromptTemplate.php
+++ b/src/Prompts/HumanMessagePromptTemplate.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Kambo\Langchain\Prompts;
+
+use Kambo\Langchain\Message\HumanMessage;
+use Kambo\Langchain\Message\BaseMessage;
+
+class HumanMessagePromptTemplate extends BaseStringMessagePromptTemplate
+{
+    /**
+     * Format the prompt and return a BaseMessage
+     *
+     * @param array $arguments
+     * @return BaseMessage
+     */
+    public function format(array $arguments = []): BaseMessage
+    {
+        $text = $this->prompt->format($arguments);
+        return new HumanMessage(
+            $text,
+            $this->additionalArguments,
+        );
+    }
+}

--- a/src/Prompts/MessagesPlaceholder.php
+++ b/src/Prompts/MessagesPlaceholder.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Kambo\Langchain\Prompts;
+
+use Kambo\Langchain\Exceptions\InvalidArgumentException;
+use Kambo\Langchain\Message\BaseMessage;
+
+use function is_array;
+use function json_encode;
+
+/**
+ * Prompt template that assumes variable is already list of messages.
+ */
+class MessagesPlaceholder extends BaseMessagePromptTemplate
+{
+    protected string $variableName;
+
+    /**
+     * @param string $variableName
+     */
+    public function __construct(string $variableName)
+    {
+        $this->variableName = $variableName;
+    }
+
+    /**
+     * Format arguments into a list of messages
+     *
+     * @param array $arguments
+     * @return BaseMessage[]
+     */
+    public function formatMessages(array $arguments = []): array
+    {
+        $value = $arguments[$this->variableName];
+
+        if (!is_array($value)) {
+            throw new InvalidArgumentException(
+                'Variable '
+                . $this->variableName
+                . ' should be a list of base messages, got '
+                . json_encode($value)
+            );
+        }
+
+        foreach ($value as $v) {
+            if (!($v instanceof BaseMessage)) {
+                throw new InvalidArgumentException(
+                    'Variable '
+                    . $this->variableName
+                    . ' should be a list of base messages, got '
+                    . json_encode($value)
+                );
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get input variables for this prompt template
+     *
+     * @return array
+     */
+    public function getInputVariables(): array
+    {
+        return [$this->variableName];
+    }
+}

--- a/src/Prompts/PromptTemplate.php
+++ b/src/Prompts/PromptTemplate.php
@@ -38,8 +38,6 @@ class PromptTemplate extends StringPromptTemplate
      * @param string $template
      * @param array  $inputVariables
      * @param array  $settings
-     *
-     * @throws InvalidFormat
      */
     public function __construct(
         string $template = '',

--- a/src/Prompts/SystemMessagePromptTemplate.php
+++ b/src/Prompts/SystemMessagePromptTemplate.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Kambo\Langchain\Prompts;
+
+use Kambo\Langchain\Message\SystemMessage;
+use Kambo\Langchain\Message\BaseMessage;
+
+class SystemMessagePromptTemplate extends BaseStringMessagePromptTemplate
+{
+    /**
+     * Format the prompt and return a BaseMessage
+     *
+     * @param array $arguments
+     * @return BaseMessage
+     */
+    public function format(array $arguments = []): BaseMessage
+    {
+        $text = $this->prompt->format($arguments);
+        return new SystemMessage(
+            $text,
+            $this->additionalArguments
+        );
+    }
+}

--- a/tests/Prompts/MessagePromptTest.php
+++ b/tests/Prompts/MessagePromptTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Kambo\Langchain\Tests\Prompts;
+
+use PHPUnit\Framework\TestCase;
+use Kambo\Langchain\Prompts\AIMessagePromptTemplate;
+use Kambo\Langchain\Prompts\ChatMessagePromptTemplate;
+use Kambo\Langchain\Prompts\HumanMessagePromptTemplate;
+use Kambo\Langchain\Prompts\SystemMessagePromptTemplate;
+use Kambo\Langchain\Prompts\PromptTemplate;
+use Kambo\Langchain\Prompts\ChatPromptTemplate;
+use Kambo\Langchain\Prompts\ChatPromptValue;
+use Kambo\Langchain\Message\HumanMessage;
+
+use function array_merge;
+use function array_key_last;
+
+class MessagePromptTest extends TestCase
+{
+    public function testChatPromptTemplate(): void
+    {
+        $promptTemplate = new ChatPromptTemplate(
+            $this->createMessages(),
+            ['foo', 'bar', 'context'],
+        );
+        $prompt = $promptTemplate->formatPrompt(['foo' => 'foo', 'bar' => 'bar', 'context' => 'context']);
+
+        $this->assertInstanceOf(ChatPromptValue::class, $prompt);
+
+        $messages = $prompt->toMessages();
+        $this->assertCount(4, $messages);
+        $this->assertEquals("Here's some context: context", $messages[0]->getContent());
+        $this->assertEquals("Hello foo, I'm bar. Thanks for the context", $messages[1]->getContent());
+        $this->assertEquals("I'm an AI. I'm foo. I'm bar.", $messages[2]->getContent());
+        $this->assertEquals("I'm a generic message. I'm foo. I'm bar.", $messages[3]->getContent());
+
+        $expected = "System: Here's some context: context\nHuman: Hello foo, I'm bar. Thanks for the context\nAI: I'm an AI. I'm foo. I'm bar.\ntest: I'm a generic message. I'm foo. I'm bar.";
+        $this->assertEquals($expected, (string)$prompt);
+
+        $string = $promptTemplate->format(['foo' => 'foo', 'bar' => 'bar', 'context' => 'context']);
+        $this->assertEquals($expected, $string);
+    }
+
+    public function testChatPromptTemplateFromMessages(): void
+    {
+        $chatPromptTemplate = ChatPromptTemplate::fromMessages($this->createMessages());
+        $this->assertEqualsCanonicalizing(['context', 'foo', 'bar'], $chatPromptTemplate->getInputVariables());
+        $this->assertCount(4, $chatPromptTemplate->getMessages());
+    }
+
+    public function testChatPromptTemplateWithMessages(): void
+    {
+        $messages = array_merge($this->createMessages(), [new HumanMessage('foo')]);
+        $chatPromptTemplate = ChatPromptTemplate::fromMessages($messages);
+        $this->assertEqualsCanonicalizing(['context', 'foo', 'bar'], $chatPromptTemplate->getInputVariables());
+        $this->assertCount(5, $chatPromptTemplate->getMessages());
+
+        $promptValue = $chatPromptTemplate->formatPrompt(['context' => 'see', 'foo' => 'this', 'bar' => 'magic']);
+        $promptValueMessages = $promptValue->toMessages();
+        $this->assertEquals(new HumanMessage('foo'), $promptValueMessages[array_key_last($promptValueMessages)]);
+    }
+
+    protected function createMessages(): array
+    {
+        $systemMessagePrompt = new SystemMessagePromptTemplate(
+            new PromptTemplate(
+                "Here's some context: {context}",
+                ['context'],
+            ),
+        );
+
+        $humanMessagePrompt = new HumanMessagePromptTemplate(
+            new PromptTemplate(
+                "Hello {foo}, I'm {bar}. Thanks for the {context}",
+                ['foo', 'bar', 'context'],
+            ),
+        );
+
+        $aiMessagePrompt = new AIMessagePromptTemplate(
+            new PromptTemplate(
+                "I'm an AI. I'm {foo}. I'm {bar}.",
+                ['foo', 'bar'],
+            ),
+        );
+
+        $chatMessagePrompt = new ChatMessagePromptTemplate(
+            new PromptTemplate(
+                "I'm a generic message. I'm {foo}. I'm {bar}.",
+                ['foo', 'bar'],
+            ),
+            'test',
+        );
+
+        return [
+            $systemMessagePrompt,
+            $humanMessagePrompt,
+            $aiMessagePrompt,
+            $chatMessagePrompt,
+        ];
+    }
+}

--- a/tests/Prompts/MessagesPlaceholderTest.php
+++ b/tests/Prompts/MessagesPlaceholderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Kambo\Langchain\Tests\Prompts;
+
+use Kambo\Langchain\Message\HumanMessage;
+use Kambo\Langchain\Prompts\MessagesPlaceholder;
+use PHPUnit\Framework\TestCase;
+
+class MessagesPlaceholderTest extends TestCase
+{
+    public function testGetMessages()
+    {
+        $messages = [
+            'foo' => [
+                new HumanMessage('foo'),
+                new HumanMessage('bar'),
+            ],
+        ];
+
+        $placeholder = new MessagesPlaceholder('foo');
+
+        $this->assertEquals($messages['foo'], $placeholder->formatMessages($messages));
+    }
+}


### PR DESCRIPTION
feat(chat-prompt-template.php): add chat prompt template for language translation assistant with system and human message prompts.

refactor(ConversationBufferWindowMemory.php): use Utils class to get buffer string
feat(BaseMessage.php): add getContent method to BaseMessage class

feat(Utils.php, AIMessagePromptTemplate.php): add Utils class with getBufferString method and AIMessagePromptTemplate class for formatting AI messages

feat(Prompts): add BaseChatPromptTemplate and BaseMessagePromptTemplate classes
refactor(BasePromptTemplate.php): change parameter name from kwargs to arguments in mergePartialAndUserVariables method

feat(BaseStringMessagePromptTemplate.php): add BaseStringMessagePromptTemplate class with abstract methods for formatting arguments into a BaseMessage and a list of messages. Also, add a constructor and a static method for creating an instance of the class from a template string.

feat(ChatMessagePromptTemplate.php): add ChatMessagePromptTemplate class to format chat messages with role and arguments

feat(ChatPromptTemplate.php): add ChatPromptTemplate class with methods for creating prompt templates from strings and role strings, and for formatting messages with input variables.

feat(Prompts): add ChatPromptValue class and HumanMessagePromptTemplate class

feat(Prompts): add MessagesPlaceholder prompt template class
refactor(Prompts): remove unnecessary @throws InvalidFormat from PromptTemplate constructor

feat(Prompts): add SystemMessagePromptTemplate class for formatting system messages

test(MessagePromptTest.php): add tests for ChatPromptTemplate class and its methods

test(MessagesPlaceholderTest.php): add test for MessagesPlaceholder class' formatMessages method