### PR TITLE
add few-shot prompt template

### DIFF
--- a/examples/few-shot-example.php
+++ b/examples/few-shot-example.php
@@ -1,0 +1,63 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Kambo\Langchain\LLMs\OpenAI;
+use Kambo\Langchain\Prompts\PromptTemplate;
+use Kambo\Langchain\Chains\LLMChain;
+use Kambo\Langchain\Prompts\FewShotPromptTemplate;
+
+$examples = [
+    [
+        'query' => 'How are you?',
+        'answer' => "I can't complain but sometimes I still do."
+    ],
+    [
+        'query' => 'What time is it?',
+        'answer' => "It's time to get a watch."
+    ]
+];
+
+$exampleTemplate = '
+User: {query}
+AI: {answer}
+';
+
+$examplePrompt = new PromptTemplate(
+    $exampleTemplate,
+    ['query', 'answer'],
+);
+
+$prefix = "The following are excerpts from conversations with an AI
+assistant. The assistant is typically sarcastic and witty, producing
+creative  and funny responses to the users' questions. Here are some
+examples:
+";
+
+$suffix = '
+User: {query}
+AI: ';
+
+// now create the few-shot prompt template
+$fewShotPromptTemplate = new FewShotPromptTemplate(
+    prefix: $prefix,
+    suffix: $suffix,
+    examplePrompt: $examplePrompt,
+    inputVariables: ['query'],
+    settings: ['example_separator' => '\n\n'],
+    examples: $examples,
+);
+
+
+$llm = new OpenAI(['temperature' => 0.9]);
+
+$chain = new LLMChain($llm, $fewShotPromptTemplate);
+
+echo 'few shots: ' . $chain->run('How do birds fly?') . PHP_EOL;
+
+$plain = new PromptTemplate(
+    '{query}',
+    ['query'],
+);
+$chain = new LLMChain($llm, $plain);
+echo 'normal: ' . $chain->run('How do birds fly?') . PHP_EOL;

--- a/src/Prompts/BasePromptTemplate.php
+++ b/src/Prompts/BasePromptTemplate.php
@@ -51,7 +51,7 @@ abstract class BasePromptTemplate
             );
         }
 
-        $overall = array_intersect($this->inputVariables, $this->partialVariables);
+        $overall = array_intersect($this->inputVariables, array_keys($this->partialVariables));
         if (!empty($overall)) {
             throw new ValueError(
                 'Found overlapping input and partial variables: ' . implode(', ', $overall)

--- a/src/Prompts/ExampleSelector/BaseExampleSelector.php
+++ b/src/Prompts/ExampleSelector/BaseExampleSelector.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Kambo\Langchain\Prompts\ExampleSelector;
+
+abstract class BaseExampleSelector
+{
+    /**
+     * Add new example to store for a key.
+     *
+     * @param array $example
+     * @return mixed
+     */
+    abstract public function addExample(array $example);
+
+    /**
+     * Select which examples to use based on the inputs.
+     *
+     * @param array $input_variables
+     * @return array
+     */
+    abstract public function selectExamples(array $input_variables): array;
+}

--- a/src/Prompts/ExampleSelector/LengthBasedExampleSelector.php
+++ b/src/Prompts/ExampleSelector/LengthBasedExampleSelector.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Kambo\Langchain\Prompts\ExampleSelector;
+
+use Kambo\Langchain\Prompts\PromptTemplate;
+
+use function call_user_func;
+use function array_map;
+use function implode;
+use function array_values;
+use function count;
+use function preg_split;
+
+class LengthBasedExampleSelector extends BaseExampleSelector
+{
+    /** @var array A list of the examples that the prompt template expects. */
+    public array $examples;
+
+    /** @var PromptTemplate Prompt template used to format the examples. */
+    public PromptTemplate $examplePrompt;
+
+    /** @var callable Function to measure prompt length. Defaults to word count. */
+    public $getTextLength;
+
+    /** @var int Max length for the prompt, beyond which examples are cut. */
+    public int $maxLength = 2048;
+
+    /** @var array */
+    private array $exampleTextLengths = [];
+
+    public function __construct(
+        array $examples,
+        PromptTemplate $example_prompt,
+        callable $getTextLength = null,
+        int $max_length = 2048
+    ) {
+        $this->examples = $examples;
+        $this->examplePrompt = $example_prompt;
+        $this->getTextLength = $getTextLength ?? [$this, 'getLengthBased'];
+        $this->maxLength = $max_length;
+        $this->exampleTextLengths = $this->calculateExampleTextLengths();
+    }
+
+    public function addExample(array $example): void
+    {
+        $this->examples[] = $example;
+        $string_example = $this->examplePrompt->format($example);
+        $this->exampleTextLengths[] = call_user_func($this->getTextLength, $string_example);
+    }
+
+    private function calculateExampleTextLengths(): array
+    {
+        $string_examples = array_map(function ($eg) {
+            return $this->examplePrompt->format($eg);
+        }, $this->examples);
+
+        return array_map($this->getTextLength, $string_examples);
+    }
+
+    public function selectExamples(array $input_variables): array
+    {
+        $inputs = implode(' ', array_values($input_variables));
+        $remaining_length = $this->maxLength - call_user_func($this->getTextLength, $inputs);
+        $i = 0;
+        $examples = [];
+
+        while ($remaining_length > 0 && $i < count($this->examples)) {
+            $new_length = $remaining_length - $this->exampleTextLengths[$i];
+            if ($new_length < 0) {
+                break;
+            } else {
+                $examples[] = $this->examples[$i];
+                $remaining_length = $new_length;
+            }
+            $i++;
+        }
+
+        return $examples;
+    }
+
+    private function getLengthBased(string $text): int
+    {
+        return count(preg_split('/\n|\s/', $text));
+    }
+}

--- a/src/Prompts/FewShotPromptTemplate.php
+++ b/src/Prompts/FewShotPromptTemplate.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Kambo\Langchain\Prompts;
+
+use Kambo\Langchain\Exceptions\InvalidArgumentException;
+use Kambo\Langchain\Exceptions\InvalidFormat;
+use Kambo\Langchain\Exceptions\NotImplemented;
+use Kambo\Langchain\Exceptions\ValueError;
+use Kambo\Langchain\Prompts\Formatter\FString;
+use Kambo\Langchain\Prompts\ExampleSelector\BaseExampleSelector;
+
+use function array_merge;
+use function array_keys;
+use function array_flip;
+use function array_map;
+use function implode;
+use function array_filter;
+use function array_diff;
+
+class FewShotPromptTemplate extends StringPromptTemplate
+{
+    /**
+     * Examples to format into the prompt.
+     *  Either this or example_selector should be provided.
+     */
+    public ?array $examples = null;
+
+    /**
+     * Example selector to choose the examples to format into the prompt.
+     *  Either this or examples should be provided.
+     */
+    public ?BaseExampleSelector $exampleSelector = null;
+
+    /** PromptTemplate used to format an individual example. */
+    public PromptTemplate $examplePrompt;
+
+    /** A prompt template string to put after the examples. */
+    public string $suffix;
+
+    /** A list of the names of the variables the prompt template expects. */
+    public array $inputVariables;
+
+    /** String separator used to join the prefix, the examples, and suffix. */
+    public string $exampleSeparator = "\n\n";
+
+    /** A prompt template string to put before the examples. */
+    public string $prefix = '';
+
+    /** The format of the prompt template. Options are: 'f-string', 'jinja2'. */
+    public string $templateFormat = 'f-string';
+
+    /** Whether or not to try validating the template. */
+    public bool $validateTemplate = true;
+
+    /**
+     * @param string              $prefix
+     * @param string              $suffix
+     * @param PromptTemplate|null $examplePrompt
+     * @param array               $inputVariables
+     * @param array               $settings
+     * @param array               $examples
+     *
+     * @throws InvalidFormat
+     * @throws ValueError
+     */
+    public function __construct(
+        string $prefix = '',
+        string $suffix = '',
+        PromptTemplate $examplePrompt = null,
+        array $inputVariables = [],
+        array $settings = [],
+        array $examples = [],
+    ) {
+        $this->prefix = $prefix;
+        $this->suffix = $suffix;
+        $this->examplePrompt = $examplePrompt;
+        $this->inputVariables = $inputVariables;
+        $this->templateFormat = $settings['template_format'] ?? $this->templateFormat;
+        $this->validateTemplate = $settings['validate_template'] ?? $this->validateTemplate;
+        $this->partialVariables = $settings['partial_variables'] ?? [];
+        $this->exampleSeparator = $settings['example_separator'] ?? $this->exampleSeparator;
+        $this->examples = $examples;
+
+        $this->validateVariableNames();
+        $this->validateTemplate();
+    }
+
+    /**
+     * Check that one and only one of examples/example_selector are provided.
+     *
+     * @param array $values
+     *
+     * @return array
+     * @throws InvalidArgumentException
+     */
+    public static function checkExamplesAndSelector(array $values): array
+    {
+        $examples = $values['examples'] ?? null;
+        $example_selector = $values['example_selector'] ?? null;
+
+        if ($examples && $example_selector) {
+            throw new InvalidArgumentException("Only one of 'examples' and 'example_selector' should be provided");
+        }
+
+        if ($examples === null && $example_selector === null) {
+            throw new InvalidArgumentException("One of 'examples' and 'example_selector' should be provided");
+        }
+
+        return $values;
+    }
+
+
+    /**
+     * @return void
+     */
+    private function validateTemplate(): void
+    {
+        if ($this->validateTemplate) {
+            $allInputs = array_merge($this->inputVariables, array_keys($this->partialVariables));
+            $valid = $this->getFormatter()->validate($this->prefix . $this->suffix, array_flip($allInputs));
+            if (!$valid) {
+                throw new InvalidFormat(
+                    'Invalid format - some placeholders are missing'
+                );
+            }
+        }
+    }
+
+    /**
+     * Get the examples to use.
+     *
+     * @param array $kwargs
+     *
+     * @return array
+     * @throws InvalidArgumentException
+     */
+    private function getExamples(array $kwargs): array
+    {
+        if ($this->examples !== null) {
+            return $this->examples;
+        } elseif ($this->exampleSelector !== null) {
+            return $this->exampleSelector->selectExamples($kwargs);
+        } else {
+            throw new InvalidArgumentException();
+        }
+    }
+
+    /**
+     * Format the prompt with the inputs.
+     *
+     * @param array $parameters
+     *
+     * @return string
+     */
+    public function format(array $parameters): string
+    {
+        $parameters = $this->mergePartialAndUserVariables($parameters);
+        $examples = $this->getExamples($parameters);
+
+        $example_strings = array_map(
+            function ($example) {
+                return $this->examplePrompt->format($example);
+            },
+            $examples
+        );
+
+        $pieces = array_merge([$this->prefix
+        ], $example_strings, [$this->suffix]);
+        $template = implode($this->exampleSeparator, array_filter($pieces));
+
+        return $this->getFormatter()->format($template, $parameters);
+    }
+
+    /**
+     * Return the prompt type key.
+     *
+     * @return string
+     */
+    protected function getPromptType(): string
+    {
+        return 'few_shot';
+    }
+
+    /**
+     * Convert the class object into an associative array.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        if ($this->exampleSelector) {
+            throw new InvalidArgumentException('Saving an example selector is not currently supported');
+        }
+
+        return [
+            'examples' => $this->examples,
+            'exampleSelector' => $this->exampleSelector,
+            'example_prompt' => $this->examplePrompt,
+            'suffix' => $this->suffix,
+            'input_variables' => $this->inputVariables,
+            'example_separator' => $this->exampleSeparator,
+            'prefix' => $this->prefix,
+            'templateFormat' => $this->templateFormat,
+            'validate_template' => $this->validateTemplate,
+            'prompt_type' => $this->getPromptType(),
+            'partial_variables' => $this->partialVariables,
+        ];
+    }
+
+    /**
+     * Return a partial of the prompt template.
+     *
+     * @param array $arguments
+     *
+     * @return $this
+     */
+    public function partial(array $arguments): BasePromptTemplate
+    {
+        $promptDict = $this->toArray();
+        $inputVariables = array_diff($this->inputVariables, array_keys($arguments));
+        $promptDict['partial_variables'] = array_merge($this->partialVariables, $arguments);
+
+        return new self(
+            $promptDict['prefix'],
+            $promptDict['suffix'],
+            $promptDict['example_prompt'],
+            $inputVariables,
+            $promptDict,
+            $promptDict['examples']
+        );
+    }
+
+    private function getFormatter(): FString
+    {
+        if ($this->templateFormat === 'f-string') {
+            return (new FString());
+        }
+
+        throw new NotImplemented(
+            'Template formatter: ' . $this->templateFormat . ' is not implemented.'
+        );
+    }
+}

--- a/tests/Prompts/ExampleSelector/LengthBasedExampleSelectorTest.php
+++ b/tests/Prompts/ExampleSelector/LengthBasedExampleSelectorTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Kambo\Langchain\Tests\Prompts\ExampleSelector;
+
+use PHPUnit\Framework\TestCase;
+use Kambo\Langchain\Prompts\PromptTemplate;
+use Kambo\Langchain\Prompts\ExampleSelector\LengthBasedExampleSelector;
+
+use function array_merge;
+
+class LengthBasedExampleSelectorTest extends TestCase
+{
+    private const EXAMPLES = [
+        ['question' => "Question: who are you?\nAnswer: foo"],
+        ['question' => "Question: who are you?\nAnswer: foo"],
+    ];
+
+    public function testSelectorValid()
+    {
+        $selector = $this->selector();
+        $short_question = 'Short question?';
+        $output = $selector->selectExamples(['question' => $short_question]);
+        $this->assertEquals(self::EXAMPLES, $output);
+    }
+
+    public function testSelectorAddExample()
+    {
+        $selector = $this->selector();
+        $new_example = ['question' => "Question: what are you?\nAnswer: bar"];
+        $selector->addExample($new_example);
+        $short_question = 'Short question?';
+        $output = $selector->selectExamples(['question' => $short_question]);
+        $this->assertEquals(array_merge(self::EXAMPLES, [$new_example]), $output);
+    }
+
+    public function testSelectorTrimsOneExample()
+    {
+        $selector = $this->selector();
+        $long_question = 'I am writing a really long question,
+        this probably is going to affect the example right?';
+        $output = $selector->selectExamples(['question' => $long_question]);
+        $this->assertEquals([self::EXAMPLES[0]], $output);
+    }
+
+    public function testSelectorTrimsAllExamples()
+    {
+        $selector = $this->selector();
+        $longest_question = 'This question is super super super,
+        super super super super super super super super super super super,
+        super super super super long, this will affect the example right?';
+        $output = $selector->selectExamples(['question' => $longest_question]);
+        $this->assertEquals([], $output);
+    }
+
+    private function selector(): LengthBasedExampleSelector
+    {
+        $prompts = new PromptTemplate('{question}', ['question']);
+        return new LengthBasedExampleSelector(
+            self::EXAMPLES,
+            $prompts,
+            null,
+            30
+        );
+    }
+}

--- a/tests/Prompts/FewShotPromptTemplateTest.php
+++ b/tests/Prompts/FewShotPromptTemplateTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Kambo\Langchain\Tests\Prompts;
+
+use Kambo\Langchain\Prompts\FewShotPromptTemplate;
+use PHPUnit\Framework\TestCase;
+use Kambo\Langchain\Prompts\PromptTemplate;
+use Kambo\Langchain\Exceptions\InvalidFormat;
+
+class FewShotPromptTemplateTest extends TestCase
+{
+    private function getExamplePrompt(): PromptTemplate
+    {
+        return new PromptTemplate(
+            '{question}: {answer}',
+            ['question', 'answer'],
+        );
+    }
+
+    public function testSuffixOnly(): void
+    {
+        $suffix = 'This is a {foo} test.';
+        $inputVariables = ['foo'];
+        $prompt = new FewShotPromptTemplate(
+            suffix: $suffix,
+            examplePrompt: $this->getExamplePrompt(),
+            inputVariables: $inputVariables,
+        );
+
+        $output = $prompt->format(['foo' => 'bar']);
+        $expectedOutput = 'This is a bar test.';
+        $this->assertEquals($expectedOutput, $output);
+    }
+
+    public function testPromptMissingInputVariables(): void
+    {
+        $suffix = 'This is a {foo} test.';
+
+        $this->expectException(InvalidFormat::class);
+        new FewShotPromptTemplate(
+            suffix: $suffix,
+            examplePrompt: $this->getExamplePrompt(),
+        );
+    }
+
+    public function testPromptExtraInputVariables(): void
+    {
+        $suffix = 'This is a {foo} test.';
+        $inputVariables = ['foo', 'bar'];
+
+        $this->expectException(InvalidFormat::class);
+        new FewShotPromptTemplate(
+            suffix: $suffix,
+            examplePrompt: $this->getExamplePrompt(),
+            inputVariables: $inputVariables,
+        );
+    }
+
+    public function testFewShotFunctionality(): void
+    {
+        $prefix = 'This is a test about {content}.';
+        $suffix = 'Now you try to talk about {new_content}.';
+        $examples = [
+            ['question' => 'foo', 'answer' => 'bar'],
+            ['question' => 'baz', 'answer' => 'foo'],
+        ];
+        $inputVariable = ['content', 'new_content'];
+
+        $prompt = new FewShotPromptTemplate(
+            prefix: $prefix,
+            suffix: $suffix,
+            examplePrompt: $this->getExamplePrompt(),
+            inputVariables: $inputVariable,
+            settings: ['example_separator' => "\n"],
+            examples: $examples,
+        );
+
+        $output = $prompt->format(['content' => 'animals', 'new_content' => 'party']);
+        $expectedOutput = "This is a test about animals.\nfoo: bar\nbaz: foo\nNow you try to talk about party.";
+        $this->assertEquals($expectedOutput, $output);
+    }
+
+    public function testPartialInitString(): void
+    {
+        $prefix = 'This is a test about {content}.';
+        $suffix = 'Now you try to talk about {new_content}.';
+        $examples = [
+            ['question' => 'foo', 'answer' => 'bar'],
+            ['question' => 'baz', 'answer' => 'foo'],
+        ];
+        $inputVariable = ['new_content'];
+        $partialVariables = ['content' => 'animals'];
+
+        $prompt = new FewShotPromptTemplate(
+            prefix: $prefix,
+            suffix: $suffix,
+            examplePrompt: $this->getExamplePrompt(),
+            inputVariables: $inputVariable,
+            settings: ['example_separator' => "\n", 'partial_variables' => $partialVariables],
+            examples: $examples,
+        );
+
+        $output = $prompt->format(['new_content' => 'party']);
+        $expectedOutput = "This is a test about animals.\nfoo: bar\nbaz: foo\nNow you try to talk about party.";
+        $this->assertEquals($expectedOutput, $output);
+    }
+
+    public function testPartialInitFunc(): void
+    {
+        $prefix = 'This is a test about {content}.';
+        $suffix = 'Now you try to talk about {new_content}.';
+        $examples = [
+            ['question' => 'foo', 'answer' => 'bar'],
+            ['question' => 'baz', 'answer' => 'foo'],
+        ];
+        $inputVariable = ['new_content'];
+        $partialVariables = ['content' => function () {
+            return 'animals';
+        }];
+
+        $prompt = new FewShotPromptTemplate(
+            prefix: $prefix,
+            suffix: $suffix,
+            examplePrompt: $this->getExamplePrompt(),
+            inputVariables: $inputVariable,
+            settings: ['example_separator' => "\n", 'partial_variables' => $partialVariables],
+            examples: $examples,
+        );
+
+        $output = $prompt->format(['new_content' => 'party']);
+        $expectedOutput = "This is a test about animals.\nfoo: bar\nbaz: foo\nNow you try to talk about party.";
+        $this->assertEquals($expectedOutput, $output);
+    }
+
+    public function testPartial(): void
+    {
+        $prefix = 'This is a test about {content}.';
+        $suffix = 'Now you try to talk about {new_content}.';
+        $examples = [
+            ['question' => 'foo', 'answer' => 'bar'],
+            ['question' => 'baz', 'answer' => 'foo'],
+        ];
+        $inputVariable = ['content', 'new_content'];
+
+        $prompt = new FewShotPromptTemplate(
+            prefix: $prefix,
+            suffix: $suffix,
+            examplePrompt: $this->getExamplePrompt(),
+            inputVariables: $inputVariable,
+            settings: ['example_separator' => "\n"],
+            examples: $examples,
+        );
+
+        $newPrompt = $prompt->partial(['content' => 'foo']);
+        $newOutput = $newPrompt->format(['new_content' => 'party']);
+        $expectedOutput = "This is a test about foo.\nfoo: bar\nbaz: foo\nNow you try to talk about party.";
+        $this->assertEquals($expectedOutput, $newOutput);
+
+        $output = $prompt->format(['content' => 'bar', 'new_content' => 'party']);
+        $expectedOutput = "This is a test about bar.\nfoo: bar\nbaz: foo\nNow you try to talk about party.";
+        $this->assertEquals($expectedOutput, $output);
+    }
+}


### PR DESCRIPTION
feat(few-shot-example.php): add few-shot example with OpenAI LLMChain

fix(BasePromptTemplate.php): fix array_intersect argument to use array_keys

feat(BaseExampleSelector.php): add abstract class BaseExampleSelector with addExample and selectExamples abstract methods.

feat(LengthBasedExampleSelector.php): add LengthBasedExampleSelector class to select examples based on length of input variables and examples.

feat(FewShotPromptTemplate.php): add FewShotPromptTemplate class with support for formatting examples into a prompt template.

feat(LengthBasedExampleSelectorTest.php): add tests for LengthBasedExampleSelector class

feat(FewShotPromptTemplateTest.php): add tests for FewShotPromptTemplate class functionality